### PR TITLE
fix(tests): add retry for issue creation eventual consistency

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -19,7 +19,22 @@ create_test_issue() {
     --title "[Integration Test] $title - $run_id-$timestamp" \
     --body "$body")
   # gh issue create returns the URL; extract issue number from it
-  echo "$url" | grep -oE '[0-9]+$'
+  local issue_number
+  issue_number=$(echo "$url" | grep -oE '[0-9]+$')
+
+  # Wait for issue to be queryable (GitHub eventual consistency)
+  local retries=0
+  while [ "$retries" -lt 5 ]; do
+    if gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json number --jq '.number' >/dev/null 2>&1; then
+      echo "$issue_number"
+      return 0
+    fi
+    echo "Waiting for issue #$issue_number to become queryable (attempt $((retries + 1))/5)..." >&2
+    sleep 2
+    retries=$((retries + 1))
+  done
+
+  echo "$issue_number"
 }
 
 # Wait for a workflow run triggered after a given timestamp


### PR DESCRIPTION
## Summary

- Add retry loop in `create_test_issue()` to wait for the issue to become queryable after creation
- Fixes `Could not resolve to an issue or pull request` GraphQL errors caused by GitHub eventual consistency with App tokens

## Root Cause

`gh issue create` returns successfully but the issue may not be immediately resolvable via GraphQL (especially with GitHub App tokens). The test scripts immediately try to comment on the issue, which fails.

## Test Plan

- [x] Verified the fix adds a 5-attempt retry with 2s backoff
- [ ] Integration test re-run after merge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>