### PR TITLE
feat: add prettier formatting enforcement and integration test

### DIFF
--- a/.github/claude-instructions/00-formatting.md
+++ b/.github/claude-instructions/00-formatting.md
@@ -1,0 +1,15 @@
+# Code Formatting Requirements
+
+## CRITICAL: Run Prettier Before Every Commit
+
+This project uses Prettier for code formatting. CI will reject any PR with unformatted code.
+
+**Before EVERY `git commit`, you MUST run these commands in order:**
+
+```bash
+npm ci                    # Install dependencies (includes prettier)
+npx prettier --write .    # Format all files
+npm run format:check      # Verify formatting passes
+```
+
+If you skip formatting, CI will fail immediately on the "Check code formatting" step.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check code formatting
+        run: npm run format:check
+
       - name: Basic validation
         run: |
           echo "CI check passed"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,6 +88,33 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bash scripts/test-label-auto-advance.sh
 
+  test-formatting-enforcement:
+    runs-on: diranged-claude-tests
+    needs: [test-label-design]
+    if: >-
+      always()
+      && (needs.test-label-design.result == 'success' || needs.test-label-design.result == 'skipped')
+      && (contains(inputs.tests || 'all', 'formatting')
+        || contains(inputs.tests || 'all', 'all'))
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install gh CLI
+        uses: dev-hanz-ops/install-gh-cli-action@v0.2.0
+
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.INTEGRATION_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_APP_KEY }}
+
+      - name: Test Formatting Enforcement
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: bash scripts/test-formatting-enforcement.sh
+
   test-engineer-manager:
     runs-on: diranged-claude-tests
     if: >-
@@ -118,6 +145,7 @@ jobs:
       - test-mention-responder
       - test-label-design
       - test-label-auto-advance
+      - test-formatting-enforcement
       - test-engineer-manager
     if: always()
     steps:
@@ -131,6 +159,7 @@ jobs:
           echo "| Mention Responder | ${{ needs.test-mention-responder.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Label Design | ${{ needs.test-label-design.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Auto-Advance | ${{ needs.test-label-auto-advance.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Formatting Enforcement | ${{ needs.test-formatting-enforcement.result }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Engineer Manager | ${{ needs.test-engineer-manager.result }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report to main repo
@@ -143,11 +172,12 @@ jobs:
           MENTION="${{ needs.test-mention-responder.result }}"
           DESIGN="${{ needs.test-label-design.result }}"
           AUTO="${{ needs.test-label-auto-advance.result }}"
+          FORMATTING="${{ needs.test-formatting-enforcement.result }}"
           ENGINEER="${{ needs.test-engineer-manager.result }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           # Determine overall status
-          if [ "$MENTION" = "success" ] && [ "$DESIGN" = "success" ] && [ "$AUTO" = "success" ] && [ "$ENGINEER" = "success" ]; then
+          if [ "$MENTION" = "success" ] && [ "$DESIGN" = "success" ] && [ "$AUTO" = "success" ] && [ "$FORMATTING" = "success" ] && [ "$ENGINEER" = "success" ]; then
             OVERALL="All tests passed"
             ICON="white_check_mark"
           else
@@ -156,5 +186,5 @@ jobs:
           fi
 
           echo "Integration tests completed: $OVERALL"
-          echo "Results: mention=$MENTION design=$DESIGN auto-advance=$AUTO engineer=$ENGINEER"
+          echo "Results: mention=$MENTION design=$DESIGN auto-advance=$AUTO formatting=$FORMATTING engineer=$ENGINEER"
           echo "Run URL: $RUN_URL"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "claude-workflows-integration-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-workflows-integration-tests",
+      "devDependencies": {
+        "prettier": "^3.4.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "claude-workflows-integration-tests",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "devDependencies": {
+    "prettier": "^3.4.0"
+  }
+}

--- a/scripts/test-formatting-enforcement.sh
+++ b/scripts/test-formatting-enforcement.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+echo "=== Test: Formatting Enforcement ==="
+
+# Track seen run IDs
+SEEN_RUNS=""
+
+# 1. Create test issue that requires writing TypeScript code
+ISSUE=$(create_test_issue \
+  "Formatting Enforcement Test" \
+  "Add a new TypeScript file at src/utils.ts that exports a function called add(a: number, b: number): number that returns the sum of two numbers. Include a JSDoc comment on the function.")
+echo "Created issue #$ISSUE"
+trap "cleanup_test_issue $ISSUE" EXIT
+
+# 2. Apply claude:design + claude:auto_advance
+echo "Applying claude:design and claude:auto_advance labels to issue #$ISSUE..."
+gh issue edit "$ISSUE" \
+  --repo "$GITHUB_REPOSITORY" \
+  --add-label "claude:design" --add-label "claude:auto_advance"
+
+# 3. Wait for design phase
+echo "--- Phase 1: Design ---"
+RUN_ID=$(wait_for_triggered_run "claude-engineers.yml" 120)
+SEEN_RUNS="$RUN_ID"
+echo "Design run: $RUN_ID"
+wait_for_completion "$RUN_ID" 1200
+
+# 4. Wait for review phase
+echo "--- Phase 2: Review ---"
+sleep 30
+RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
+SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
+echo "Review run: $RUN_ID"
+wait_for_completion "$RUN_ID" 1200
+
+# 5. Wait for implement phase
+echo "--- Phase 3: Implement ---"
+sleep 30
+RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
+SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
+echo "Implement run: $RUN_ID"
+wait_for_completion "$RUN_ID" 1200
+
+# 6. Verify PR was created
+echo "Checking for PR linked to issue #$ISSUE..."
+PR=$(gh pr list \
+  --repo "$GITHUB_REPOSITORY" \
+  --json number,body \
+  --jq ".[] | select(.body | contains(\"#$ISSUE\")) | .number" | head -1)
+
+if [ -z "$PR" ]; then
+  print_result "FAIL" "No PR created linking to issue #$ISSUE"
+  exit 1
+fi
+echo "PR #$PR created successfully"
+
+# 7. Wait for CI to run on the PR
+echo "Waiting for CI to run on PR #$PR..."
+sleep 30
+CI_RUN=$(gh run list \
+  --repo "$GITHUB_REPOSITORY" \
+  --workflow "ci.yml" \
+  --limit 5 \
+  --json databaseId,headBranch,status \
+  --jq "[.[] | select(.status != \"completed\")] | .[0].databaseId // empty" 2>/dev/null || true)
+
+if [ -z "$CI_RUN" ]; then
+  # CI might have already completed, check the latest
+  CI_RUN=$(gh run list \
+    --repo "$GITHUB_REPOSITORY" \
+    --workflow "ci.yml" \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId' 2>/dev/null || true)
+fi
+
+if [ -n "$CI_RUN" ]; then
+  echo "CI run: $CI_RUN"
+  # Wait for CI completion
+  gh run watch "$CI_RUN" --repo "$GITHUB_REPOSITORY" --interval 10 2>/dev/null || true
+
+  CI_CONCLUSION=$(gh run view "$CI_RUN" --repo "$GITHUB_REPOSITORY" --json conclusion --jq '.conclusion')
+  echo "CI conclusion: $CI_CONCLUSION"
+
+  if [ "$CI_CONCLUSION" = "success" ]; then
+    print_result "PASS" "Formatting enforcement working — PR #$PR passes CI formatting check"
+  else
+    print_result "FAIL" "PR #$PR failed CI (conclusion: $CI_CONCLUSION) — agent may not have run prettier"
+    exit 1
+  fi
+else
+  echo "Warning: Could not find CI run for PR #$PR"
+  print_result "WARN" "PR created but could not verify CI formatting check"
+fi

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,7 @@
+/**
+ * Example TypeScript file for integration testing.
+ * Used to verify the agent respects prettier formatting.
+ */
+export function greet(name: string): string {
+  return `Hello, ${name}!`;
+}


### PR DESCRIPTION
## Summary
- Adds prettier as a dev dependency with format/format:check scripts
- CI now checks code formatting on all PRs
- `.github/claude-instructions/00-formatting.md` instructs the agent to run prettier before every commit
- New `test-formatting-enforcement.sh` integration test validates the agent produces properly formatted PRs
- Report job updated to include formatting test results

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run integration-tests.yml -f tests=formatting` to validate end-to-end