### PR TITLE
fix: format all existing files with prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "CI"
+name: 'CI'
 
 on:
   pull_request:
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/claude-engineer-managers.yml
+++ b/.github/workflows/claude-engineer-managers.yml
@@ -1,10 +1,10 @@
-name: "Engineer Managers"
+name: 'Engineer Managers'
 
 on:
   workflow_dispatch:
     inputs:
       engineer:
-        description: "Which engineer to test"
+        description: 'Which engineer to test'
         required: true
         type: choice
         options:
@@ -26,10 +26,10 @@ jobs:
       - uses: diranged/claude-code-agentic-workflows/claude-engineer@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
-          allowed_bots: "claude[bot],claude-workflows-integration-test[bot]"
+          allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'
           agent_name: ${{ inputs.engineer }}
-          dashboard_label: "integration-test:${{ inputs.engineer }}"
-          task_label: "integration-test:${{ inputs.engineer }}-task"
-          delegation_label: "integration-test:design"
-          max_implementations: "0"
-          timeout_minutes: "30"
+          dashboard_label: 'integration-test:${{ inputs.engineer }}'
+          task_label: 'integration-test:${{ inputs.engineer }}-task'
+          delegation_label: 'integration-test:design'
+          max_implementations: '0'
+          timeout_minutes: '30'

--- a/.github/workflows/claude-engineers.yml
+++ b/.github/workflows/claude-engineers.yml
@@ -1,10 +1,10 @@
-name: "Claude Engineers"
+name: 'Claude Engineers'
 
 on:
   issues:
     types: [labeled]
   workflow_run:
-    workflows: ["CI"]
+    workflows: ['CI']
     types: [completed]
 
 jobs:
@@ -25,8 +25,8 @@ jobs:
     uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@main
     with:
       runner: diranged-claude-tests
-      allowed_bots: "claude[bot],claude-workflows-integration-test[bot]"
-      allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"
+      allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'
+      allowed_tools: 'Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch'
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
       app_id: ${{ secrets.INTEGRATION_APP_ID }}
@@ -45,7 +45,7 @@ jobs:
     uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-engineers.yml@main
     with:
       runner: diranged-claude-tests
-      ci_retry: "true"
-      ci_retry_max: "3"
+      ci_retry: 'true'
+      ci_retry_max: '3'
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-responder.yml
+++ b/.github/workflows/claude-responder.yml
@@ -1,4 +1,4 @@
-name: "Claude Responder"
+name: 'Claude Responder'
 
 on:
   issue_comment:
@@ -20,7 +20,7 @@ jobs:
     uses: diranged/claude-code-agentic-workflows/.github/workflows/shared-claude-responder.yml@main
     with:
       runner: diranged-claude-tests
-      allowed_bots: "claude[bot],claude-workflows-integration-test[bot]"
-      allowed_tools: "Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch"
+      allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'
+      allowed_tools: 'Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch'
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: "Integration Tests"
+name: 'Integration Tests'
 
 on:
   repository_dispatch:
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Ref of main repo to test against"
-        default: "main"
+        description: 'Ref of main repo to test against'
+        default: 'main'
       tests:
         description: "Tests to run (comma-separated or 'all')"
-        default: "all"
+        default: 'all'
 
 jobs:
   test-mention-responder:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This repo mirrors what real consumers do — thin caller workflows that consume 
 ## Structure
 
 - `.github/workflows/claude-responder.yml` — Caller: @claude mentions
-- `.github/workflows/claude-engineers.yml` — Caller: claude:* labels
+- `.github/workflows/claude-engineers.yml` — Caller: claude:\* labels
 - `.github/workflows/claude-engineer-managers.yml` — Caller: engineer workflow_dispatch
 - `.github/workflows/ci.yml` — Minimal CI (for CI retry testing)
 - `.github/workflows/integration-tests.yml` — Orchestrator: runs all test scenarios
@@ -20,6 +20,7 @@ This repo mirrors what real consumers do — thin caller workflows that consume 
 ## Running Tests
 
 Tests are triggered via:
+
 1. `repository_dispatch` from the main repo (post-merge to main)
 2. `workflow_dispatch` in this repo (manual ad-hoc runs)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository acts as a real consumer of the shared workflows, exercising end-
 ### GitHub App
 
 A dedicated GitHub App ("Claude Workflows Integration Test") with:
+
 - Issues: Read & Write
 - Pull requests: Read & Write
 - Contents: Read & Write
@@ -25,15 +26,16 @@ Install on this repository only.
 
 ### Secrets
 
-| Secret | Description |
-|--------|-------------|
-| `CLAUDE_OAUTH_TOKEN` | Claude Code OAuth token for authentication |
-| `INTEGRATION_APP_ID` | GitHub App ID |
-| `INTEGRATION_APP_KEY` | GitHub App private key (PEM) |
+| Secret                | Description                                |
+| --------------------- | ------------------------------------------ |
+| `CLAUDE_OAUTH_TOKEN`  | Claude Code OAuth token for authentication |
+| `INTEGRATION_APP_ID`  | GitHub App ID                              |
+| `INTEGRATION_APP_KEY` | GitHub App private key (PEM)               |
 
 ### Main Repo Secret
 
 The main repo (`diranged/claude-code-agentic-workflows`) needs:
+
 - `INTEGRATION_TEST_PAT` — PAT with `repo` scope for `repository_dispatch`
 
 ## Running Tests
@@ -57,9 +59,9 @@ gh workflow run integration-tests.yml -f tests=design
 
 ## Test Scenarios
 
-| Test | Flow | Duration |
-|------|------|----------|
-| `mention` | @claude comment → response | ~2-3 min |
-| `design` | claude:design → designer agent | ~5 min |
-| `auto-advance` | design → review → implement pipeline | ~15-20 min |
-| `engineer` | Engineer manager → dashboard creation | ~10-15 min |
+| Test           | Flow                                  | Duration   |
+| -------------- | ------------------------------------- | ---------- |
+| `mention`      | @claude comment → response            | ~2-3 min   |
+| `design`       | claude:design → designer agent        | ~5 min     |
+| `auto-advance` | design → review → implement pipeline  | ~15-20 min |
+| `engineer`     | Engineer manager → dashboard creation | ~10-15 min |


### PR DESCRIPTION
## Summary
Existing files in the repo weren't formatted with prettier, causing every PR to fail the `format:check` CI step regardless of agent behavior.

Also adds `.gitignore` to exclude `node_modules/`.