### PR TITLE
fix(workflows): add allowed_bots to claude-engineer step

### DIFF
--- a/.github/workflows/claude-engineer-managers.yml
+++ b/.github/workflows/claude-engineer-managers.yml
@@ -36,3 +36,4 @@ jobs:
           max_implementations: '0'
           timeout_minutes: '30'
           force_rotation: ${{ inputs.force_rotation && 'true' || 'false' }}
+          allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'


### PR DESCRIPTION
## Summary
- Adds `allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'` to the claude-engineer step in the engineer managers workflow

## Test plan
- [ ] Verify workflow dispatch still works with the new parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)