### PR TITLE
fix(workflows): add compose_prompt and agent_name inputs

### DIFF
--- a/.github/workflows/claude-engineers.yml
+++ b/.github/workflows/claude-engineers.yml
@@ -24,5 +24,6 @@ jobs:
           app_id: ${{ secrets.INTEGRATION_APP_ID }}
           app_private_key: ${{ secrets.INTEGRATION_APP_KEY }}
           label_trigger: 'claude'
+          compose_prompt: 'true'
           allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'
           allowed_tools: 'Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch'

--- a/.github/workflows/claude-responder.yml
+++ b/.github/workflows/claude-responder.yml
@@ -22,5 +22,7 @@ jobs:
       - uses: diranged/claude-code-agentic-workflows/claude-respond@integ-testing
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+          compose_prompt: 'true'
+          agent_name: 'auto'
           allowed_bots: 'claude[bot],claude-workflows-integration-test[bot]'
           allowed_tools: 'Bash(*),Read,Glob,Grep,Edit,Write,WebFetch,WebSearch'


### PR DESCRIPTION
## Summary
- Add `compose_prompt: 'true'` to both `claude-engineers.yml` and `claude-responder.yml` so the prompt composition system runs and agents get their personality/instructions
- Add `agent_name: 'auto'` to `claude-responder.yml` for automatic agent selection

## Test plan
- [ ] Verify claude-engineers workflow triggers correctly with compose_prompt enabled
- [ ] Verify claude-responder workflow triggers correctly with compose_prompt and agent_name

🤖 Generated with [Claude Code](https://claude.com/claude-code)