### PR TITLE
fix(scripts): use label-based waiting to fix race condition in parallel tests

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -134,6 +134,84 @@ wait_for_completion() {
   }
 }
 
+# Wait for an issue to gain a specific label
+# Usage: wait_for_label "issue_number" "label_name" [max_wait_seconds]
+wait_for_label() {
+  local issue_number="$1"
+  local label="$2"
+  local max_wait="${3:-600}"
+
+  echo "Waiting for label '$label' on issue #$issue_number (max ${max_wait}s)..." >&2
+
+  local elapsed=0
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    local labels
+    labels=$(gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+    if echo ",$labels," | grep -q ",$label,"; then
+      echo "Label '$label' found on issue #$issue_number" >&2
+      return 0
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  echo "ERROR: Label '$label' not found on issue #$issue_number within ${max_wait}s" >&2
+  return 1
+}
+
+# Wait for a label to be removed from an issue
+# Usage: wait_for_label_removed "issue_number" "label_name" [max_wait_seconds]
+wait_for_label_removed() {
+  local issue_number="$1"
+  local label="$2"
+  local max_wait="${3:-600}"
+
+  echo "Waiting for label '$label' to be removed from issue #$issue_number (max ${max_wait}s)..." >&2
+
+  local elapsed=0
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    local labels
+    labels=$(gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || true)
+    if ! echo ",$labels," | grep -q ",$label,"; then
+      echo "Label '$label' removed from issue #$issue_number" >&2
+      return 0
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  echo "ERROR: Label '$label' still present on issue #$issue_number after ${max_wait}s" >&2
+  return 1
+}
+
+# Wait for a PR linked to a specific issue
+# Usage: wait_for_linked_pr "issue_number" [max_wait_seconds]
+# Returns: PR number
+wait_for_linked_pr() {
+  local issue_number="$1"
+  local max_wait="${2:-300}"
+
+  echo "Waiting for PR linked to issue #$issue_number (max ${max_wait}s)..." >&2
+
+  local elapsed=0
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    local pr
+    pr=$(gh pr list \
+      --repo "$GITHUB_REPOSITORY" \
+      --json number,body \
+      --jq ".[] | select(.body | contains(\"#$issue_number\")) | .number" 2>/dev/null | head -1 || true)
+    if [ -n "$pr" ]; then
+      echo "$pr"
+      return 0
+    fi
+    sleep 10
+    elapsed=$((elapsed + 10))
+  done
+
+  echo "ERROR: No PR found linking to issue #$issue_number within ${max_wait}s" >&2
+  return 1
+}
+
 # Verify issue has a tracking comment from Claude
 # Usage: verify_tracking_comment <issue_number>
 verify_tracking_comment() {

--- a/scripts/test-formatting-enforcement.sh
+++ b/scripts/test-formatting-enforcement.sh
@@ -4,9 +4,6 @@ source "$(dirname "$0")/lib.sh"
 
 echo "=== Test: Formatting Enforcement ==="
 
-# Track seen run IDs
-SEEN_RUNS=""
-
 # 1. Create test issue that requires writing TypeScript code
 ISSUE=$(create_test_issue \
   "Formatting Enforcement Test" \
@@ -20,77 +17,58 @@ gh issue edit "$ISSUE" \
   --repo "$GITHUB_REPOSITORY" \
   --add-label "claude:design" --add-label "claude:auto_advance"
 
-# 3. Wait for design phase
+# 3. Wait for full pipeline: design → review → implement
 echo "--- Phase 1: Design ---"
-RUN_ID=$(wait_for_triggered_run "claude-engineers.yml" 120)
-SEEN_RUNS="$RUN_ID"
-echo "Design run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
+wait_for_label "$ISSUE" "claude:review" 600
+echo "Design phase completed"
 
-# 4. Wait for review phase
 echo "--- Phase 2: Review ---"
-sleep 30
-RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
-SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
-echo "Review run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
+wait_for_label "$ISSUE" "claude:implement" 1200
+echo "Review phase completed"
 
-# 5. Wait for implement phase
+# 4. Wait for PR
 echo "--- Phase 3: Implement ---"
+PR=$(wait_for_linked_pr "$ISSUE" 600)
+echo "PR #$PR created"
+
+# 5. Wait for CI to run on the PR
+echo "Waiting for CI on PR #$PR..."
 sleep 30
-RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
-SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
-echo "Implement run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
 
-# 6. Verify PR was created
-echo "Checking for PR linked to issue #$ISSUE..."
-PR=$(gh pr list \
-  --repo "$GITHUB_REPOSITORY" \
-  --json number,body \
-  --jq ".[] | select(.body | contains(\"#$ISSUE\")) | .number" | head -1)
-
-if [ -z "$PR" ]; then
-  print_result "FAIL" "No PR created linking to issue #$ISSUE"
-  exit 1
-fi
-echo "PR #$PR created successfully"
-
-# 7. Wait for CI to run on the PR
-echo "Waiting for CI to run on PR #$PR..."
-sleep 30
-CI_RUN=$(gh run list \
-  --repo "$GITHUB_REPOSITORY" \
-  --workflow "ci.yml" \
-  --limit 5 \
-  --json databaseId,headBranch,status \
-  --jq "[.[] | select(.status != \"completed\")] | .[0].databaseId // empty" 2>/dev/null || true)
-
-if [ -z "$CI_RUN" ]; then
-  # CI might have already completed, check the latest
+# Find CI run for this PR's branch
+PR_BRANCH=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json headRefName --jq '.headRefName')
+CI_RUN=""
+ELAPSED=0
+while [ "$ELAPSED" -lt 120 ]; do
   CI_RUN=$(gh run list \
     --repo "$GITHUB_REPOSITORY" \
     --workflow "ci.yml" \
+    --branch "$PR_BRANCH" \
     --limit 1 \
     --json databaseId \
-    --jq '.[0].databaseId' 2>/dev/null || true)
+    --jq '.[0].databaseId // empty' 2>/dev/null || true)
+  if [ -n "$CI_RUN" ]; then
+    break
+  fi
+  sleep 10
+  ELAPSED=$((ELAPSED + 10))
+done
+
+if [ -z "$CI_RUN" ]; then
+  echo "Warning: Could not find CI run for PR #$PR (branch: $PR_BRANCH)"
+  print_result "WARN" "PR created but could not verify CI formatting check"
+  exit 0
 fi
 
-if [ -n "$CI_RUN" ]; then
-  echo "CI run: $CI_RUN"
-  # Wait for CI completion
-  gh run watch "$CI_RUN" --repo "$GITHUB_REPOSITORY" --interval 10 2>/dev/null || true
+echo "CI run: $CI_RUN"
+gh run watch "$CI_RUN" --repo "$GITHUB_REPOSITORY" --interval 10 2>/dev/null || true
 
-  CI_CONCLUSION=$(gh run view "$CI_RUN" --repo "$GITHUB_REPOSITORY" --json conclusion --jq '.conclusion')
-  echo "CI conclusion: $CI_CONCLUSION"
+CI_CONCLUSION=$(gh run view "$CI_RUN" --repo "$GITHUB_REPOSITORY" --json conclusion --jq '.conclusion')
+echo "CI conclusion: $CI_CONCLUSION"
 
-  if [ "$CI_CONCLUSION" = "success" ]; then
-    print_result "PASS" "Formatting enforcement working — PR #$PR passes CI formatting check"
-  else
-    print_result "FAIL" "PR #$PR failed CI (conclusion: $CI_CONCLUSION) — agent may not have run prettier"
-    exit 1
-  fi
+if [ "$CI_CONCLUSION" = "success" ]; then
+  print_result "PASS" "Formatting enforcement working — PR #$PR passes CI formatting check"
 else
-  echo "Warning: Could not find CI run for PR #$PR"
-  print_result "WARN" "PR created but could not verify CI formatting check"
+  print_result "FAIL" "PR #$PR failed CI (conclusion: $CI_CONCLUSION) — agent may not have run prettier"
+  exit 1
 fi

--- a/scripts/test-label-auto-advance.sh
+++ b/scripts/test-label-auto-advance.sh
@@ -4,56 +4,35 @@ source "$(dirname "$0")/lib.sh"
 
 echo "=== Test: Full Auto-Advance Pipeline ==="
 
-# Track seen run IDs to avoid matching the same run in multiple phases
-SEEN_RUNS=""
-
 # 1. Create test issue
 ISSUE=$(create_test_issue \
   "Auto-Advance Pipeline Test" \
-  "Create a file called integration-test.txt containing 'Auto-advance test passed'.")
+  "Create a file called integration-test.txt at the root of the repository with the content 'Auto-advance test passed'. Nothing else.")
 echo "Created issue #$ISSUE"
 trap "cleanup_test_issue $ISSUE" EXIT
 
-# 2. Apply claude:design + claude:auto_advance (triggers full pipeline)
+# 2. Apply claude:design + claude:auto_advance
 echo "Applying claude:design and claude:auto_advance labels to issue #$ISSUE..."
 gh issue edit "$ISSUE" \
   --repo "$GITHUB_REPOSITORY" \
   --add-label "claude:design" --add-label "claude:auto_advance"
 
-# 3. Wait for design phase
+# 3. Wait for design phase to complete (label changes from design to review)
 echo "--- Phase 1: Design ---"
-RUN_ID=$(wait_for_triggered_run "claude-engineers.yml" 120)
-SEEN_RUNS="$RUN_ID"
-echo "Design run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
+wait_for_label "$ISSUE" "claude:review" 600
+echo "Design phase completed — issue advanced to review"
 
-# 4. Wait for review phase (auto-triggered by designer adding claude:review)
+# 4. Wait for review phase to complete (label changes from review to implement)
 echo "--- Phase 2: Review ---"
-sleep 30
-RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
-SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
-echo "Review run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
+wait_for_label "$ISSUE" "claude:implement" 1200
+echo "Review phase completed — issue advanced to implement"
 
-# 5. Wait for implement phase (auto-triggered by architect adding claude:implement)
+# 5. Wait for implementation to produce a PR
 echo "--- Phase 3: Implement ---"
-sleep 30
-RUN_ID=$(wait_for_new_run "claude-engineers.yml" "$SEEN_RUNS" 300)
-SEEN_RUNS="$SEEN_RUNS,$RUN_ID"
-echo "Implement run: $RUN_ID"
-wait_for_completion "$RUN_ID" 1200
+PR=$(wait_for_linked_pr "$ISSUE" 600)
+echo "Implementation complete — PR #$PR created"
 
-# 6. Verify PR was created
-echo "Checking for PR linked to issue #$ISSUE..."
-PR=$(gh pr list \
-  --repo "$GITHUB_REPOSITORY" \
-  --json number,body \
-  --jq ".[] | select(.body | contains(\"#$ISSUE\")) | .number" | head -1)
+# 6. Verify tracking comment exists
+verify_tracking_comment "$ISSUE"
 
-if [ -z "$PR" ]; then
-  print_result "FAIL" "No PR created linking to issue #$ISSUE"
-  exit 1
-fi
-echo "PR #$PR created successfully"
-
-print_result "PASS" "Full auto-advance pipeline working"
+print_result "PASS" "Full auto-advance pipeline working — design → review → implement → PR #$PR"


### PR DESCRIPTION
## Summary
- Add `wait_for_label`, `wait_for_label_removed`, and `wait_for_linked_pr` helper functions to `scripts/lib.sh`
- Rewrite `test-label-auto-advance.sh` to poll issue labels instead of tracking workflow run IDs
- Rewrite `test-formatting-enforcement.sh` with the same label-based approach and branch-scoped CI lookup

## Problem
When auto-advance and formatting tests run in parallel, they trigger overlapping `claude-engineers.yml` workflow runs. The `wait_for_new_run` function picks up runs from the wrong test issue, causing flaky failures.

## Fix
Instead of tracking workflow run IDs (global to the repo), each test now polls the labels on its own issue. This is inherently scoped to the correct test since each test creates its own issue.

## Test plan
- [ ] Run integration tests with both auto-advance and formatting tests in parallel
- [ ] Verify no cross-talk between test issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)